### PR TITLE
Sugerencias cambio enunciado Números

### DIFF
--- a/03-Numeros/Numeros-Parte1-Ejercicio.st
+++ b/03-Numeros/Numeros-Parte1-Ejercicio.st
@@ -1,4 +1,4 @@
-!classDefinition: #NumeroTest category: #'Numeros-Parte1-Ejercicio'!
+!classDefinition: #NumeroTest category: 'Numeros-Parte1-Ejercicio'!
 TestCase subclass: #NumeroTest
 	instanceVariableNames: 'zero one two four oneFifth oneHalf five twoFifth twoTwentyfifth fiveHalfs three eight negativeOne negativeTwo'
 	classVariableNames: ''
@@ -128,38 +128,40 @@ setUp
 	! !
 
 
-!classDefinition: #Numero category: #'Numeros-Parte1-Ejercicio'!
+!classDefinition: #Numero category: 'Numeros-Parte1-Ejercicio'!
 Object subclass: #Numero
 	instanceVariableNames: 'type value numerator denominator'
 	classVariableNames: ''
 	poolDictionaries: ''
 	category: 'Numeros-Parte1-Ejercicio'!
 
-!Numero methodsFor: 'arithmetic operations' stamp: 'LL 9/13/2020 16:33:53'!
+!Numero methodsFor: 'arithmetic operations' stamp: 'LL 11/7/2020 18:50:54'!
 * aMultiplier 
 
 	type = #Entero ifTrue:	
-		[ ^self class with: value * aMultiplier integerValue ].
+		[ aMultiplier type = #Entero ifTrue: [ ^self class with: value * aMultiplier integerValue ] ].
 		
 	type = #Fraccion ifTrue:
-		[ ^self class with: (numerator * aMultiplier numerator) over: (denominator * aMultiplier denominator) ].
+		[ aMultiplier type = #Fraccion ifTrue: [ ^self class with: (numerator * aMultiplier numerator) over: (denominator * aMultiplier denominator) ] ].
 		
 	self error: 'Tipo de número no soportado'
 	! !
 
-!Numero methodsFor: 'arithmetic operations' stamp: 'LL 9/13/2020 16:35:06'!
+!Numero methodsFor: 'arithmetic operations' stamp: 'LL 11/7/2020 18:53:18'!
 + anAdder 
 	
 	type = #Entero ifTrue:
-		[ ^self class with: value + anAdder integerValue ].
+		[ anAdder type = #Entero ifTrue: [ ^self class with: value + anAdder integerValue ] ].
 	
 	type = #Fraccion ifTrue:
-		[ | newNumerator newDenominator |
+		[ anAdder type = #Fraccion ifTrue: [
+			| newNumerator newDenominator |
 		
-		newNumerator := (numerator * anAdder denominator) + (denominator * anAdder numerator).
-		newDenominator := denominator * anAdder denominator.
-		
-		^ self class with: newNumerator over: newDenominator ].
+			newNumerator := (numerator * anAdder denominator) + (denominator * anAdder numerator).
+			newDenominator := denominator * anAdder denominator.
+			
+			^ self class with: newNumerator over: newDenominator ] 
+		].
 	
 	self error: 'Tipo de número no soportado'
 	! !
@@ -291,7 +293,7 @@ greatestCommonDivisorWith: anEntero
 
 "-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- "!
 
-!classDefinition: 'Numero class' category: #'Numeros-Parte1-Ejercicio'!
+!classDefinition: 'Numero class' category: 'Numeros-Parte1-Ejercicio'!
 Numero class
 	instanceVariableNames: ''!
 

--- a/03-Numeros/Numeros-Parte1-Ejercicio.st
+++ b/03-Numeros/Numeros-Parte1-Ejercicio.st
@@ -1,4 +1,4 @@
-!classDefinition: #NumeroTest category: 'Numeros-Parte1-Ejercicio'!
+!classDefinition: #NumeroTest category: #'Numeros-Parte1-Ejercicio'!
 TestCase subclass: #NumeroTest
 	instanceVariableNames: 'zero one two four oneFifth oneHalf five twoFifth twoTwentyfifth fiveHalfs three eight negativeOne negativeTwo'
 	classVariableNames: ''
@@ -128,40 +128,38 @@ setUp
 	! !
 
 
-!classDefinition: #Numero category: 'Numeros-Parte1-Ejercicio'!
+!classDefinition: #Numero category: #'Numeros-Parte1-Ejercicio'!
 Object subclass: #Numero
 	instanceVariableNames: 'type value numerator denominator'
 	classVariableNames: ''
 	poolDictionaries: ''
 	category: 'Numeros-Parte1-Ejercicio'!
 
-!Numero methodsFor: 'arithmetic operations' stamp: 'LL 11/7/2020 18:50:54'!
+!Numero methodsFor: 'arithmetic operations' stamp: 'LL 9/13/2020 16:33:53'!
 * aMultiplier 
 
 	type = #Entero ifTrue:	
-		[ aMultiplier type = #Entero ifTrue: [ ^self class with: value * aMultiplier integerValue ] ].
+		[ ^self class with: value * aMultiplier integerValue ].
 		
 	type = #Fraccion ifTrue:
-		[ aMultiplier type = #Fraccion ifTrue: [ ^self class with: (numerator * aMultiplier numerator) over: (denominator * aMultiplier denominator) ] ].
+		[ ^self class with: (numerator * aMultiplier numerator) over: (denominator * aMultiplier denominator) ].
 		
 	self error: 'Tipo de número no soportado'
 	! !
 
-!Numero methodsFor: 'arithmetic operations' stamp: 'LL 11/7/2020 18:53:18'!
+!Numero methodsFor: 'arithmetic operations' stamp: 'LL 9/13/2020 16:35:06'!
 + anAdder 
 	
 	type = #Entero ifTrue:
-		[ anAdder type = #Entero ifTrue: [ ^self class with: value + anAdder integerValue ] ].
+		[ ^self class with: value + anAdder integerValue ].
 	
 	type = #Fraccion ifTrue:
-		[ anAdder type = #Fraccion ifTrue: [
-			| newNumerator newDenominator |
+		[ | newNumerator newDenominator |
 		
-			newNumerator := (numerator * anAdder denominator) + (denominator * anAdder numerator).
-			newDenominator := denominator * anAdder denominator.
-			
-			^ self class with: newNumerator over: newDenominator ] 
-		].
+		newNumerator := (numerator * anAdder denominator) + (denominator * anAdder numerator).
+		newDenominator := denominator * anAdder denominator.
+		
+		^ self class with: newNumerator over: newDenominator ].
 	
 	self error: 'Tipo de número no soportado'
 	! !
@@ -293,7 +291,7 @@ greatestCommonDivisorWith: anEntero
 
 "-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- "!
 
-!classDefinition: 'Numero class' category: 'Numeros-Parte1-Ejercicio'!
+!classDefinition: 'Numero class' category: #'Numeros-Parte1-Ejercicio'!
 Numero class
 	instanceVariableNames: ''!
 

--- a/03-Numeros/Numeros-Parte1-Ejercicio.st
+++ b/03-Numeros/Numeros-Parte1-Ejercicio.st
@@ -253,13 +253,13 @@ printOn: aStream
 			print: denominator ].! !
 
 
-!Numero methodsFor: 'comparing' stamp: 'LL 9/13/2020 16:49:07'!
+!Numero methodsFor: 'comparing' stamp: 'LL 9/15/2020 11:00:17'!
 = anObject
 
 	((anObject isKindOf: self class) and: [ type = anObject type ]) ifTrue: [
 		type = #Entero ifTrue: [ ^value = anObject integerValue ].
 		type = #Fraccion ifTrue: [ ^(numerator * anObject denominator) = (denominator * anObject numerator) ].
-		self error: 'Tipo de número no soportado'
+		^false
 	].
 
 	^false

--- a/03-Numeros/Numeros-Parte1-Ejercicio.st
+++ b/03-Numeros/Numeros-Parte1-Ejercicio.st
@@ -135,25 +135,25 @@ Object subclass: #Numero
 	poolDictionaries: ''
 	category: 'Numeros-Parte1-Ejercicio'!
 
-!Numero methodsFor: 'arithmetic operations' stamp: 'NR 9/9/2019 15:44:29'!
+!Numero methodsFor: 'arithmetic operations' stamp: 'LL 9/13/2020 16:33:53'!
 * aMultiplier 
 
-	(type = #Entero and: [aMultiplier type = #Entero]) ifTrue:	
+	type = #Entero ifTrue:	
 		[ ^self class with: value * aMultiplier integerValue ].
 		
-	(type = #Fraccion and: [aMultiplier type = #Fraccion]) ifTrue:
+	type = #Fraccion ifTrue:
 		[ ^self class with: (numerator * aMultiplier numerator) over: (denominator * aMultiplier denominator) ].
 		
 	self error: 'Tipo de número no soportado'
 	! !
 
-!Numero methodsFor: 'arithmetic operations' stamp: 'NR 9/9/2019 15:44:40'!
+!Numero methodsFor: 'arithmetic operations' stamp: 'LL 9/13/2020 16:35:06'!
 + anAdder 
 	
-	(type = #Entero and: [anAdder type = #Entero]) ifTrue:
+	type = #Entero ifTrue:
 		[ ^self class with: value + anAdder integerValue ].
 	
-	(type = #Fraccion and: [anAdder type = #Fraccion]) ifTrue:
+	type = #Fraccion ifTrue:
 		[ | newNumerator newDenominator |
 		
 		newNumerator := (numerator * anAdder denominator) + (denominator * anAdder numerator).
@@ -164,11 +164,12 @@ Object subclass: #Numero
 	self error: 'Tipo de número no soportado'
 	! !
 
-!Numero methodsFor: 'arithmetic operations' stamp: 'NR 9/8/2019 23:19:57'!
+!Numero methodsFor: 'arithmetic operations' stamp: 'LL 9/13/2020 16:35:23'!
 negated
 	
 	type = #Entero ifTrue:
 		[ ^self * (self class with: -1) ].
+		
 	type = #Fraccion ifTrue:
 		[ ^self class with: numerator * (self class with: -1) over: denominator ].! !
 
@@ -252,13 +253,17 @@ printOn: aStream
 			print: denominator ].! !
 
 
-!Numero methodsFor: 'comparing' stamp: 'NR 9/8/2019 21:50:26'!
+!Numero methodsFor: 'comparing' stamp: 'LL 9/13/2020 16:49:07'!
 = anObject
 
-	^(anObject isKindOf: self class) and: [ type = anObject type and: 
-		[ type = #Entero ifTrue: [ value = anObject integerValue] 
-		ifFalse: [ type = #Fraccion ifTrue:
-			[ (numerator * anObject denominator) = (denominator * anObject numerator) ]]]]! !
+	((anObject isKindOf: self class) and: [ type = anObject type ]) ifTrue: [
+		type = #Entero ifTrue: [ ^value = anObject integerValue ].
+		type = #Fraccion ifTrue: [ ^(numerator * anObject denominator) = (denominator * anObject numerator) ].
+		self error: 'Tipo de número no soportado'
+	].
+
+	^false
+! !
 
 !Numero methodsFor: 'comparing' stamp: 'NR 9/8/2019 22:00:49'!
 hash
@@ -276,11 +281,11 @@ hash
 		
 	self error: 'Tipo de número no soportado'! !
 
-!Numero methodsFor: 'arithmetic operations - private' stamp: 'NR 9/9/2019 16:21:17'!
+!Numero methodsFor: 'arithmetic operations - private' stamp: 'LL 9/13/2020 16:50:25'!
 greatestCommonDivisorWith: anEntero 
 	
 	type = #Entero ifTrue:
-		[^self class with: (value gcd: anEntero integerValue)].
+		[ ^self class with: (value gcd: anEntero integerValue) ].
 		
 	self error: 'Tipo de número no soportado'! !
 


### PR DESCRIPTION
Estuve revisando este ejercicio. Viendo los videos del cuatri pasado, los alumnes parece que les confunde esto de que haya un pre ejercicio, sin enunciado, y luego esté el ejercicio "final". A mi personalmente también me resulta confuso, y cuando se los pasé a los ayudantes de FIUBA tampoco lo entendieron.

Por este motivo, cambié la consigna agregando una parte 1 y una parte 2, con lo que antes era el pre y el ejercicio definitivo. La pueden ver acá: https://github.com/UBA-FCEN-FIUBA/ejercicios-poo/blob/master/03-Numeros/Consigna.md Allí se aclara que no es necesario que entreguen la solución a la 1er parte.

Por otro lado, del código de la parte 1 (ex pre ejercicio) sugiero que quitemos las condiciones de if sobre los colaboradores, ya que creo que los va a marear cuando tengan que sacar los ifs. Tampoco hay tests que cubran eso. Además, la solución a este pre ejercicio que les damos ignora estos ifs a colaboradores, y directamente falla la implementación para esos casos de operaciones cruzadas.

Este PR también incluye un segundo cambio menor, que es cambio a la implementación del =, para que quede un poco más legible (menos ifs encadenados).

Escucho sus opiniones :) Gracias!